### PR TITLE
Add item name and onAfterShow event

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ Demo: https://vasilionjea.github.io/ember-a11y-accordion/
 {{#accordion-list
   class="my-accordion"
   animation=false
-  onShow=(action "onAccordionShow") as |accordion|}}
-  {{#accordion.item expandOnInit=true as |item|}}
+  onShow=(action "onAccordionShow") 
+  onAfterShow=(action "onAccordionAfterShow") as |accordion|}}
+  {{#accordion.item name="item1" expandOnInit=true as |item|}}
     {{#item.header class="first-header" aria-level="4"}}Lorem ipsum{{/item.header}}
     {{#item.panel class="first-panel"}}
       <p>Lorem <a href="#">ipsum</a> dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
     {{/item.panel}}
   {{/accordion.item}}
 
-  {{#accordion.item as |item|}}
+  {{#accordion.item name="item2" as |item|}}
     {{#item.header aria-level="4"}}Dolor Sit{{/item.header}}
     {{#item.panel}}
       <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
@@ -35,7 +36,8 @@ Demo: https://vasilionjea.github.io/ember-a11y-accordion/
 ```
 
 There is an additional collapsible component called `collapsible-list` and all the options are exactly the same as the accordion list component. The only difference is that accordions expand one item at a time, whereas collapsibles can have multiple items expanded at any point in time. Also the `collapsible-list` component accepts an `onHide` action in addition to the `onShow` action.
-
+`onShow` is triggered when the header is clicked, `onAfterShow` is triggered once the content is visible and all animations completed.
+`onHide`, `onShow` and `onAfterShow` will receive an object as first argument with a name property containing the `name` of the `accordion-item` becoming visible and other properties.
 
 ## Roles, States, Attributes, and Classes
 

--- a/addon/components/accordion-item.js
+++ b/addon/components/accordion-item.js
@@ -37,6 +37,7 @@ export default Component.extend({
       panelId: guidFor({}),
       isExpanded: this.get('expandOnInit'),
       isDisabled: this.get('isDisabled'),
+      name: this.get('name'),
     });
 
     this.set('sharedState', sharedState);

--- a/addon/components/collapsible-list.js
+++ b/addon/components/collapsible-list.js
@@ -67,6 +67,7 @@ export default Component.extend({
       isExpanded: true,
       'panelWrapper.style.display': null,
     });
+    this.triggerEvent('onAfterShow', item);
   },
 
   /**
@@ -88,6 +89,7 @@ export default Component.extend({
       if (item.get('isExpanded') && !this._isHiding) {
         item.panelWrapper.style.height = null;
       }
+      this.triggerEvent('onAfterShow', item);
     });
   },
 
@@ -105,7 +107,7 @@ export default Component.extend({
     });
 
     if (!silent) {
-      this.get('onHide') && this.get('onHide')();
+      this.triggerEvent('onHide', item);
     }
   },
 
@@ -133,7 +135,7 @@ export default Component.extend({
       item.set('isExpanded', false);
       this._isHiding = false;
 
-      this.get('onHide') && this.get('onHide')();
+      this.triggerEvent('onHide', item);
     }, INLINE_HEIGHT_DELAY);
   },
 
@@ -143,6 +145,19 @@ export default Component.extend({
   willDestroyElement() {
     cancel(this._currentHideTimeout);
     this.set('items', null);
+  },
+
+  /**
+   * Triggers an event
+   *
+   * @param {string} eventName
+   * @param {Object} item
+   * @private
+   */
+  triggerEvent(eventName, item) {
+    this.get(eventName) && this.get(eventName)({
+      name: item.get('name'),
+    });
   },
 
   actions: {
@@ -188,7 +203,7 @@ export default Component.extend({
           ? this.animatedShow(item)
           : this.simpleShow(item);
 
-        this.get('onShow') && this.get('onShow')();
+        this.triggerEvent('onShow', item);
       }
     },
   },

--- a/addon/components/collapsible-list.js
+++ b/addon/components/collapsible-list.js
@@ -67,7 +67,6 @@ export default Component.extend({
       isExpanded: true,
       'panelWrapper.style.display': null,
     });
-    this.triggerEvent('onAfterShow', item);
   },
 
   /**
@@ -88,8 +87,8 @@ export default Component.extend({
     addEventListenerOnce(item.panelWrapper, 'transitionend', () => {
       if (item.get('isExpanded') && !this._isHiding) {
         item.panelWrapper.style.height = null;
+        this.triggerEvent('onAfterShow', item);
       }
-      this.triggerEvent('onAfterShow', item);
     });
   },
 
@@ -199,11 +198,14 @@ export default Component.extend({
           ? this.animatedHide(item)
           : this.simpleHide(item);
       } else {
-        this.get('animation')
-          ? this.animatedShow(item)
-          : this.simpleShow(item);
-
-        this.triggerEvent('onShow', item);
+        if (this.get('animation')) {
+          this.animatedShow(item)
+          this.triggerEvent('onShow', item);
+        } else {
+          this.simpleShow(item);
+          this.triggerEvent('onShow', item);
+          this.triggerEvent('onAfterShow', item);
+        }
       }
     },
   },

--- a/tests/integration/components/collapsible-list-test.js
+++ b/tests/integration/components/collapsible-list-test.js
@@ -157,15 +157,16 @@ test('it should expand the item when its header is clicked and animation is set 
 });
 
 test('it should execute the onShow action when one is provided', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  this.set('doSomethingOnShow', () => {
+  this.set('doSomethingOnShow', (item) => {
     assert.ok(true);
+    assert.equal(item.name, 'item1');
   });
 
   this.render(hbs`
     {{#collapsible-list onShow=(action doSomethingOnShow) as |collapsible|}}
-      {{#collapsible.item as |item|}}
+      {{#collapsible.item name="item1" as |item|}}
         {{#item.header}}header here...{{/item.header}}
         {{#item.panel}}panel here...{{/item.panel}}
       {{/collapsible.item}}
@@ -176,15 +177,56 @@ test('it should execute the onShow action when one is provided', function(assert
 });
 
 test('it should execute the onShow action when one is provided and animation is set to false', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  this.set('doSomethingOnShow', () => {
+  this.set('doSomethingOnShow', (item) => {
     assert.ok(true);
+    assert.equal(item.name, 'item1');
   });
 
   this.render(hbs`
     {{#collapsible-list animation=false onShow=(action doSomethingOnShow) as |collapsible|}}
-      {{#collapsible.item as |item|}}
+      {{#collapsible.item name="item1" as |item|}}
+        {{#item.header}}header here...{{/item.header}}
+        {{#item.panel}}panel here...{{/item.panel}}
+      {{/collapsible.item}}
+    {{/collapsible-list}}
+  `);
+
+  click(SELECTORS.header);
+});
+
+test('it should execute the onAfterShow action when one is provided', function(assert) {
+  assert.expect(2);
+
+  this.set('doSomethingOnAfterShow', (item) => {
+    assert.ok(true);
+    assert.equal(item.name, 'item1');
+  });
+
+  this.render(hbs`
+    {{#collapsible-list onAfterShow=(action doSomethingOnAfterShow) as |collapsible|}}
+      {{#collapsible.item name="item1" as |item|}}
+        {{#item.header}}header here...{{/item.header}}
+        {{#item.panel}}panel here...{{/item.panel}}
+      {{/collapsible.item}}
+    {{/collapsible-list}}
+  `);
+
+  return click(SELECTORS.header);
+});
+
+test('it should execute the onAfterShow action when one is provided and animation is set to false', function(assert) {
+  assert.expect(2);
+
+  this.set('doSomethingOnAfterShow', (item) => {
+    assert.ok(true);
+    assert.equal(item.name, 'item1');
+  });
+
+  this.render(hbs`
+    {{#collapsible-list animation=false onAfterShow=(action doSomethingOnAfterShow) as |collapsible|}}
+      {{#collapsible.item name="item1" as |item|}}
         {{#item.header}}header here...{{/item.header}}
         {{#item.panel}}panel here...{{/item.panel}}
       {{/collapsible.item}}
@@ -195,15 +237,16 @@ test('it should execute the onShow action when one is provided and animation is 
 });
 
 test('it should execute the onHide action when one is provided', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  this.set('doSomethingOnHide', () => {
+  this.set('doSomethingOnHide', (item) => {
     assert.ok(true);
+    assert.equal(item.name, 'item1');
   });
 
   this.render(hbs`
     {{#collapsible-list onHide=(action doSomethingOnHide) as |collapsible|}}
-      {{#collapsible.item expandOnInit=true as |item|}}
+      {{#collapsible.item name="item1" expandOnInit=true as |item|}}
         {{#item.header}}header here...{{/item.header}}
         {{#item.panel}}panel here...{{/item.panel}}
       {{/collapsible.item}}
@@ -214,15 +257,16 @@ test('it should execute the onHide action when one is provided', function(assert
 });
 
 test('it should execute the onHide action when one is provided and animation is set to false', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  this.set('doSomethingOnHide', () => {
+  this.set('doSomethingOnHide', (item) => {
     assert.ok(true);
+    assert.equal(item.name, 'item1');
   });
 
   this.render(hbs`
     {{#collapsible-list animation=false onHide=(action doSomethingOnHide) as |collapsible|}}
-      {{#collapsible.item expandOnInit=true as |item|}}
+      {{#collapsible.item name="item1" expandOnInit=true as |item|}}
         {{#item.header}}header here...{{/item.header}}
         {{#item.panel}}panel here...{{/item.panel}}
       {{/collapsible.item}}

--- a/tests/integration/components/collapsible-list-test.js
+++ b/tests/integration/components/collapsible-list-test.js
@@ -199,9 +199,12 @@ test('it should execute the onShow action when one is provided and animation is 
 test('it should execute the onAfterShow action when one is provided', function(assert) {
   assert.expect(2);
 
+  const done = assert.async();
+
   this.set('doSomethingOnAfterShow', (item) => {
     assert.ok(true);
     assert.equal(item.name, 'item1');
+    done();
   });
 
   this.render(hbs`
@@ -234,6 +237,75 @@ test('it should execute the onAfterShow action when one is provided and animatio
   `);
 
   click(SELECTORS.header);
+});
+
+test('it should execute the onShow and onAfterShow actions in the right order', function(assert) {
+  assert.expect(6);
+
+  const done = assert.async();
+  let doSomethingOnShowCalled = false;
+  let doSomethingOnAfterShowCalled = false;
+
+  this.set('doSomethingOnShow', (item) => {
+    doSomethingOnShowCalled = true;
+    assert.ok(true);
+    assert.notOk(doSomethingOnAfterShowCalled);
+    assert.equal(item.name, 'item1');
+  });
+
+  this.set('doSomethingOnAfterShow', (item) => {
+    doSomethingOnAfterShowCalled = true;
+    assert.ok(true);
+    assert.ok(doSomethingOnShowCalled);
+    assert.equal(item.name, 'item1');
+    done();
+  });
+
+  this.render(hbs`
+    {{#collapsible-list onShow=(action doSomethingOnShow) onAfterShow=(action doSomethingOnAfterShow) as |collapsible|}}
+      {{#collapsible.item name="item1" as |item|}}
+        {{#item.header}}header here...{{/item.header}}
+        {{#item.panel}}panel here...{{/item.panel}}
+      {{/collapsible.item}}
+    {{/collapsible-list}}
+  `);
+
+  return click(SELECTORS.header);
+});
+
+test('it should execute the onShow and onAfterShow actions in the right order when animation is set to false', function(assert) {
+  assert.expect(6);
+
+  const done = assert.async();
+
+  let doSomethingOnShowCalled = false;
+  let doSomethingOnAfterShowCalled = false;
+
+  this.set('doSomethingOnShow', (item) => {
+    doSomethingOnShowCalled = true;
+    assert.ok(true);
+    assert.notOk(doSomethingOnAfterShowCalled);
+    assert.equal(item.name, 'item1');
+  });
+
+  this.set('doSomethingOnAfterShow', (item) => {
+    doSomethingOnAfterShowCalled = true;
+    assert.ok(true);
+    assert.ok(doSomethingOnShowCalled);
+    assert.equal(item.name, 'item1');
+    done();
+  });
+
+  this.render(hbs`
+    {{#collapsible-list action=false onShow=(action doSomethingOnShow) onAfterShow=(action doSomethingOnAfterShow) as |collapsible|}}
+      {{#collapsible.item name="item1" as |item|}}
+        {{#item.header}}header here...{{/item.header}}
+        {{#item.panel}}panel here...{{/item.panel}}
+      {{/collapsible.item}}
+    {{/collapsible-list}}
+  `);
+
+  return click(SELECTORS.header);
 });
 
 test('it should execute the onHide action when one is provided', function(assert) {


### PR DESCRIPTION
In this change:
1) triggering a new `onAfterShow` event, which is fired AFTER the panel content is made visible (e.g.: after all animations completed). Useful to do things like focusing items inside the panel after the content is expanded;
1) accepting an (optional) `name` property in the `accordion-item` component;
1) sending the `name` property to the `onHide`, `onShow` and `onAfterShow` events, so that the event listener can determine which panel was expanded/collapsed.

Open issue: test `it should execute the onAfterShow action when one is provided` currently failing as the `onAfterShow` is fired in a different runloop when `animated=true`.

@vasilionjea can you please take a look?