### PR TITLE
Add onAfterShow support to accordion-list

### DIFF
--- a/addon/components/accordion-list.js
+++ b/addon/components/accordion-list.js
@@ -81,6 +81,7 @@ export default Component.extend({
     addEventListenerOnce(item.panelWrapper, 'transitionend', () => {
       if (item.get('isExpanded')) {
         item.panelWrapper.style.height = null;
+        this.triggerEvent('onAfterShow', item);
       }
     });
   },
@@ -131,6 +132,19 @@ export default Component.extend({
     this.set('items', null);
   },
 
+  /**
+   * Triggers an event
+   *
+   * @param {string} eventName
+   * @param {Object} item
+   * @private
+   */
+  triggerEvent(eventName, item) {
+    this.get(eventName) && this.get(eventName)({
+      name: item.get('name'),
+    });
+  },
+
   actions: {
     /**
      * Action for item components to register themselves.
@@ -179,12 +193,16 @@ export default Component.extend({
       }
 
       // Show this one
-      this.get('animation')
-        ? this.animatedShow(item)
-        : this.simpleShow(item);
+      if (this.get('animation')) {
+        this.animatedShow(item)
+        this.triggerEvent('onShow', item);
+      } else {
+        this.simpleShow(item);
+        this.triggerEvent('onShow', item);
+        this.triggerEvent('onAfterShow', item);
+      }
 
       this.activeItem = item;
-      this.get('onShow') && this.get('onShow')();
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-native-dom-helpers": "^0.6.2",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~2.18.0",
+    "ember-source": "~2.12.0",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3",

--- a/tests/integration/components/accordion-list-test.js
+++ b/tests/integration/components/accordion-list-test.js
@@ -263,7 +263,7 @@ test('it should execute the onShow and onAfterShow actions in the right order', 
 
   this.render(hbs`
     {{#accordion-list onShow=(action doSomethingOnShow) onAfterShow=(action doSomethingOnAfterShow) as |accordion|}}
-      {{#accordion.item name='item1' as |item|}}
+      {{#accordion.item name="item1" as |item|}}
         {{#item.header}}header here...{{/item.header}}
         {{#item.panel}}panel here...{{/item.panel}}
       {{/accordion.item}}
@@ -298,7 +298,7 @@ test('it should execute the onShow and onAfterShow actions in the right order wh
 
   this.render(hbs`
     {{#accordion-list animation=false onShow=(action doSomethingOnShow) onAfterShow=(action doSomethingOnAfterShow) as |accordion|}}
-      {{#accordion.item name='item1' as |item|}}
+      {{#accordion.item name="item1" as |item|}}
         {{#item.header}}header here...{{/item.header}}
         {{#item.panel}}panel here...{{/item.panel}}
       {{/accordion.item}}

--- a/tests/integration/components/accordion-list-test.js
+++ b/tests/integration/components/accordion-list-test.js
@@ -157,15 +157,16 @@ test('it should expand the item when its header is clicked and animation is set 
 });
 
 test('it should execute the onShow action when one is provided', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  this.set('doSomething', () => {
+  this.set('doSomething', (item) => {
     assert.ok(true);
+    assert.equal(item.name, 'item1');
   });
 
   this.render(hbs`
     {{#accordion-list onShow=(action doSomething) as |accordion|}}
-      {{#accordion.item as |item|}}
+      {{#accordion.item name="item1" as |item|}}
         {{#item.header}}header here...{{/item.header}}
         {{#item.panel}}panel here...{{/item.panel}}
       {{/accordion.item}}
@@ -176,15 +177,16 @@ test('it should execute the onShow action when one is provided', function(assert
 });
 
 test('it should execute the onShow action when one is provided and animation is set to false', function(assert) {
-  assert.expect(1);
+  assert.expect(2);
 
-  this.set('doSomething', () => {
+  this.set('doSomething', (item) => {
     assert.ok(true);
+    assert.equal(item.name, 'item1');
   });
 
   this.render(hbs`
     {{#accordion-list animation=false onShow=(action doSomething) as |accordion|}}
-      {{#accordion.item as |item|}}
+      {{#accordion.item name="item1" as |item|}}
         {{#item.header}}header here...{{/item.header}}
         {{#item.panel}}panel here...{{/item.panel}}
       {{/accordion.item}}
@@ -192,4 +194,116 @@ test('it should execute the onShow action when one is provided and animation is 
   `);
 
   click(SELECTORS.header);
+});
+
+test('it should execute the onAfterShow action when one is provided', function(assert) {
+  assert.expect(2);
+
+  const done = assert.async();
+
+  this.set('doSomething', (item) => {
+    assert.ok(true);
+    assert.equal(item.name, 'item1');
+    done();
+  });
+
+  this.render(hbs`
+    {{#accordion-list onAfterShow=(action doSomething) as |accordion|}}
+      {{#accordion.item name="item1" as |item|}}
+        {{#item.header}}header here...{{/item.header}}
+        {{#item.panel}}panel here...{{/item.panel}}
+      {{/accordion.item}}
+    {{/accordion-list}}
+  `);
+
+  click(SELECTORS.header);
+});
+
+test('it should execute the onAfterShow action when one is provided and animation is set to false', function(assert) {
+  assert.expect(2);
+
+  this.set('doSomething', (item) => {
+    assert.ok(true);
+    assert.equal(item.name, 'item1');
+  });
+
+  this.render(hbs`
+    {{#accordion-list animation=false onAfterShow=(action doSomething) as |accordion|}}
+      {{#accordion.item name='item1' as |item|}}
+        {{#item.header}}header here...{{/item.header}}
+        {{#item.panel}}panel here...{{/item.panel}}
+      {{/accordion.item}}
+    {{/accordion-list}}
+  `);
+
+  click(SELECTORS.header);
+});
+
+test('it should execute the onShow and onAfterShow actions in the right order', function(assert) {
+  assert.expect(6);
+
+  const done = assert.async();
+  let doSomethingOnShowCalled = false;
+  let doSomethingOnAfterShowCalled = false;
+
+  this.set('doSomethingOnShow', (item) => {
+    doSomethingOnShowCalled = true;
+    assert.ok(true);
+    assert.notOk(doSomethingOnAfterShowCalled);
+    assert.equal(item.name, 'item1');
+  });
+
+  this.set('doSomethingOnAfterShow', (item) => {
+    doSomethingOnAfterShowCalled = true;
+    assert.ok(true);
+    assert.ok(doSomethingOnShowCalled);
+    assert.equal(item.name, 'item1');
+    done();
+  });
+
+  this.render(hbs`
+    {{#accordion-list onShow=(action doSomethingOnShow) onAfterShow=(action doSomethingOnAfterShow) as |accordion|}}
+      {{#accordion.item name='item1' as |item|}}
+        {{#item.header}}header here...{{/item.header}}
+        {{#item.panel}}panel here...{{/item.panel}}
+      {{/accordion.item}}
+    {{/accordion-list}}
+  `);
+
+  return click(SELECTORS.header);
+});
+
+test('it should execute the onShow and onAfterShow actions in the right order when animation is set to false', function(assert) {
+  assert.expect(6);
+
+  const done = assert.async();
+
+  let doSomethingOnShowCalled = false;
+  let doSomethingOnAfterShowCalled = false;
+
+  this.set('doSomethingOnShow', (item) => {
+    doSomethingOnShowCalled = true;
+    assert.ok(true);
+    assert.notOk(doSomethingOnAfterShowCalled);
+    assert.equal(item.name, 'item1');
+  });
+
+  this.set('doSomethingOnAfterShow', (item) => {
+    doSomethingOnAfterShowCalled = true;
+    assert.ok(true);
+    assert.ok(doSomethingOnShowCalled);
+    assert.equal(item.name, 'item1');
+    done();
+  });
+
+  this.render(hbs`
+    {{#accordion-list animation=false onShow=(action doSomethingOnShow) onAfterShow=(action doSomethingOnAfterShow) as |accordion|}}
+      {{#accordion.item name='item1' as |item|}}
+        {{#item.header}}header here...{{/item.header}}
+        {{#item.panel}}panel here...{{/item.panel}}
+      {{/accordion.item}}
+    {{/accordion-list}}
+  `);
+
+  return click(SELECTORS.header);
 });


### PR DESCRIPTION
Follow up to https://github.com/vasilionjea/ember-a11y-accordion/pull/7 add `onAfterShow`/item name support to `accordion-list`.

@vasilionjea can you please take a look?