### PR TITLE
Remove npm as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3",
-    "npm": "^6.4.1",
     "qunit-dom": "^0.6.2"
   },
   "engines": {


### PR DESCRIPTION
`npm` doesn't seem to be necessary as a production dependency so removing it. It may have been added by mistake as part of the release process [1].

@vasilionjea can you please take a look?

[1] https://github.com/vasilionjea/ember-a11y-accordion/commit/626168b466beb96821c8a71411d2d4acfb6eba82#diff-b9cfc7f2cdf78a7f4b91a753d10865a2