### PR TITLE
Added test waiters around CSS transition animations

### DIFF
--- a/addon/components/accordion-list.js
+++ b/addon/components/accordion-list.js
@@ -8,8 +8,11 @@ import { next, cancel } from '@ember/runloop';
 import { A } from '@ember/array';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { buildWaiter } from '@ember/test-waiters';
 import { isPresent } from '@ember/utils';
 import { tracked } from '@glimmer/tracking';
+
+const waiter = buildWaiter('ember-a11y-accordion:accordion-list');
 
 /**
  * The accordion-list component is the top-most component and is responsible
@@ -34,6 +37,10 @@ export default class AccordionListClass extends Component {
   }
 
   className = CLASS_NAMES.list;
+
+  animatedHideWaitToken;
+
+  animatedShowWaitToken;
 
   @tracked
   _activeItem;
@@ -115,6 +122,7 @@ export default class AccordionListClass extends Component {
    * @private
    */
   _animatedHide(item) {
+    this.animatedHideWaitToken = waiter.beginAsync();
     if (this._activeItem) {
       // From open height
       setOpenHeight(this._activeItem);
@@ -126,6 +134,7 @@ export default class AccordionListClass extends Component {
     this._currentHideTimeout = next(() => {
       setClosedHeight(item);
       item.isExpanded = false;
+      waiter.endAsync(this.animatedHideWaitToken);
     });
   }
 
@@ -139,6 +148,7 @@ export default class AccordionListClass extends Component {
    * @private
    */
   _animatedShow(item) {
+    this.animatedShowWaitToken = waiter.beginAsync();
     setOpenHeight(item);
     item.isExpanded = true;
 
@@ -149,6 +159,7 @@ export default class AccordionListClass extends Component {
         item.panelWrapper.style.height = null;
         this._triggerEvent('onAfterShow', item);
       }
+      waiter.endAsync(this.animatedShowWaitToken);
     });
   }
 

--- a/addon/components/collapsible-list.js
+++ b/addon/components/collapsible-list.js
@@ -8,6 +8,7 @@ import { cancel, later } from '@ember/runloop';
 import { A } from '@ember/array';
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { buildWaiter } from '@ember/test-waiters';
 import { isPresent } from '@ember/utils';
 import { tracked } from '@glimmer/tracking';
 
@@ -18,6 +19,8 @@ import { tracked } from '@glimmer/tracking';
  * to 0px so the CSS transition will kick off.
  */
 const INLINE_HEIGHT_DELAY = 50;
+
+const waiter = buildWaiter('ember-a11y-accordion:collapsible-list');
 
 /**
  * The collapsible-list component is the top-most component and is responsible
@@ -43,6 +46,10 @@ export default class CollapsibleListComponent extends Component {
   }
 
   className = CLASS_NAMES.list;
+
+  animatedHideWaitToken;
+
+  animatedShowWaitToken;
 
   @tracked
   _currentHideTimeout = null;
@@ -103,6 +110,7 @@ export default class CollapsibleListComponent extends Component {
    * @private
    */
   _animatedHide(item) {
+    this.animatedHideWaitToken = waiter.beginAsync();
     this._isHiding = true;
 
     // From open height
@@ -117,6 +125,7 @@ export default class CollapsibleListComponent extends Component {
       this._isHiding = false;
 
       this._triggerEvent('onHide', item);
+      waiter.endAsync(this.animatedHideWaitToken);
     }, INLINE_HEIGHT_DELAY);
   }
 
@@ -130,6 +139,7 @@ export default class CollapsibleListComponent extends Component {
    * @private
    */
   _animatedShow(item) {
+    this.animatedShowWaitToken = waiter.beginAsync();
     setOpenHeight(item);
     item.isExpanded = true;
 
@@ -140,6 +150,7 @@ export default class CollapsibleListComponent extends Component {
         item.panelWrapper.style.height = null;
         this._triggerEvent('onAfterShow', item);
       }
+      waiter.endAsync(this.animatedShowWaitToken);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.5",
+    "@ember/test-waiters": "^3.0.0",
     "@embroider/test-setup": "^0.37.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
@@ -76,7 +77,7 @@
     "qunit-dom": "^1.6.0"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "12.* || >= 14"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
This PR adds test waiters involving CSS transitions from the animations involving showing/hiding accordion item panels. This is to address issues with consumers experiencing transient test failures.