### PR TITLE
Add dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5
+  versioning-strategy: "increase"
+  ignore:
+  - dependency-name: "ember-cli"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - dependency-name: "ember-source"
+    update-types: ["version-update:semver-major", "version-update:semver-minor"]
+  - dependency-name: "*"
+    update-types: ["version-update:semver-major"]


### PR DESCRIPTION
This PR defines a dependabot file that enables minor version updates to all dependencies except ember-cli and ember-source. For those, we will only do patch version updates. Updates will be checked on a weekly basis.