### PR TITLE
Add @ember/string as a depdendency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4068,6 +4068,15 @@
         "ember-modifier-manager-polyfill": "^1.2.0"
       }
     },
+    "@ember/string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ember/string/-/string-3.0.1.tgz",
+      "integrity": "sha512-ntnmXS+upOWVXE+rVw2l03DjdMnaGdWbYVUxUBuPJqnIGZu2XFRsoXc7E6mOw62s8i1Xh1RgTuFHN41QGIolEQ==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.26.6"
+      }
+    },
     "@ember/test-helpers": {
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/@ember/test-helpers/-/test-helpers-2.9.3.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.9.3",
     "@ember/test-waiters": "^3.0.2",
     "@embroider/test-setup": "^1.8.3",


### PR DESCRIPTION
Adding `@ember/string` as a dependency due to [this deprecation in Ember 4.x](https://deprecations.emberjs.com/v4.x/#toc_ember-string-from-ember-module)